### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/misc/maxsat/toysat/README.md
+++ b/misc/maxsat/toysat/README.md
@@ -23,4 +23,4 @@ References
   Improvements to Core-Guided binary search for MaxSAT,
   in Theory and Applications of Satisfiability Testing (SAT 2012),
   pp. 284-297.
-  <http://dx.doi.org/10.1007/978-3-642-31612-8_22>
+  <https://doi.org/10.1007/978-3-642-31612-8_22>

--- a/misc/maxsat/toysat_ls/README.md
+++ b/misc/maxsat/toysat_ls/README.md
@@ -26,9 +26,9 @@ References
   Improvements to Core-Guided binary search for MaxSAT,
   in Theory and Applications of Satisfiability Testing (SAT 2012),
   pp. 284-297.
-  <http://dx.doi.org/10.1007/978-3-642-31612-8_22>
+  <https://doi.org/10.1007/978-3-642-31612-8_22>
 
 * [2] D. Tompkins and H. Hoos, UBCSAT: An implementation and experimentation
   environment for SLS algorithms for SAT and MAX-SAT, in Theory and Applications
   of Satisfiability Testing (2004), Springer, 2005, pp. 306-320.
-  <http://dx.doi.org/10.1007/11527695_24>
+  <https://doi.org/10.1007/11527695_24>

--- a/misc/pb/README.md
+++ b/misc/pb/README.md
@@ -52,7 +52,7 @@ References
   Improvements to Core-Guided binary search for MaxSAT,
   in Theory and Applications of Satisfiability Testing (SAT 2012),
   pp. 284-297.
-  <http://dx.doi.org/10.1007/978-3-642-31612-8_22>
+  <https://doi.org/10.1007/978-3-642-31612-8_22>
 
 * [2] Masahiro Sakai. <https://github.com/msakai/toysolver>
 

--- a/misc/qbf/README.md
+++ b/misc/qbf/README.md
@@ -30,5 +30,5 @@ References
 * [1] Mikoláš Janota, William Klieber, Joao Marques-Silva, Edmund Clarke.
   Solving QBF with Counterexample Guided Refinement.
   In Theory and Applications of Satisfiability Testing (SAT 2012), pp. 114-128.
-  <http://dx.doi.org/10.1007/978-3-642-31612-8_10>
+  <https://doi.org/10.1007/978-3-642-31612-8_10>
   <https://www.cs.cmu.edu/~wklieber/papers/qbf-cegar-sat-2012.pdf>

--- a/src/ToySolver/Arith/ContiTraverso.hs
+++ b/src/ToySolver/Arith/ContiTraverso.hs
@@ -13,7 +13,7 @@
 -- * P. Conti and C. Traverso, "Buchberger algorithm and integer programming,"
 --   Applied Algebra, Algebraic Algorithms and Error-Correcting Codes,
 --   Lecture Notes in Computer Science Volume 539, 1991, pp 130-139
---   <http://dx.doi.org/10.1007/3-540-54522-0_102>
+--   <https://doi.org/10.1007/3-540-54522-0_102>
 --   <http://posso.dm.unipi.it/users/traverso/conti-traverso-ip.ps>
 --
 -- * IKEGAMI Daisuke, "数列と多項式の愛しい関係," 2011,

--- a/src/ToySolver/Data/Delta.hs
+++ b/src/ToySolver/Data/Delta.hs
@@ -17,7 +17,7 @@
 --   \"/A Fast Linear-Arithmetic Solver for DPLL(T)/\",
 --   Computer Aided Verification In Computer Aided Verification, Vol. 4144
 --   (2006), pp. 81-94.
---   <http://dx.doi.org/10.1007/11817963_11>
+--   <https://doi.org/10.1007/11817963_11>
 --   <http://yices.csl.sri.com/cav06.pdf>
 --
 -----------------------------------------------------------------------------

--- a/src/ToySolver/QBF.hs
+++ b/src/ToySolver/QBF.hs
@@ -15,7 +15,7 @@
 -- * Mikoláš Janota, William Klieber, Joao Marques-Silva, Edmund Clarke.
 --   Solving QBF with Counterexample Guided Refinement.
 --   In Theory and Applications of Satisfiability Testing (SAT 2012), pp. 114-128.
---   <http://dx.doi.org/10.1007/978-3-642-31612-8_10>
+--   <https://doi.org/10.1007/978-3-642-31612-8_10>
 --   <https://www.cs.cmu.edu/~wklieber/papers/qbf-cegar-sat-2012.pdf>
 --
 -----------------------------------------------------------------------------

--- a/src/ToySolver/SAT/PBO/BCD.hs
+++ b/src/ToySolver/SAT/PBO/BCD.hs
@@ -20,7 +20,7 @@
 --   Improvements to Core-Guided binary search for MaxSAT,
 --   in Theory and Applications of Satisfiability Testing (SAT 2012),
 --   pp. 284-297.
---   <http://dx.doi.org/10.1007/978-3-642-31612-8_22>
+--   <https://doi.org/10.1007/978-3-642-31612-8_22>
 --   <http://ulir.ul.ie/handle/10344/2771>
 -- 
 -----------------------------------------------------------------------------

--- a/src/ToySolver/SAT/PBO/BCD2.hs
+++ b/src/ToySolver/SAT/PBO/BCD2.hs
@@ -21,7 +21,7 @@
 --   Improvements to Core-Guided binary search for MaxSAT,
 --   in Theory and Applications of Satisfiability Testing (SAT 2012),
 --   pp. 284-297.
---   <http://dx.doi.org/10.1007/978-3-642-31612-8_22>
+--   <https://doi.org/10.1007/978-3-642-31612-8_22>
 --   <http://ulir.ul.ie/handle/10344/2771>
 -- 
 -----------------------------------------------------------------------------

--- a/src/ToySolver/SAT/PBO/MSU4.hs
+++ b/src/ToySolver/SAT/PBO/MSU4.hs
@@ -15,7 +15,7 @@
 --   Algorithms for Maximum Satisfiability using Unsatisfiable Cores.
 --   In Design, Automation and Test in Europe, 2008 (DATE '08). March 2008.
 --   pp. 408-413, doi:10.1109/date.2008.4484715.
---   <http://dx.doi.org/10.1109/date.2008.4484715>
+--   <https://doi.org/10.1109/date.2008.4484715>
 --   <http://eprints.soton.ac.uk/265000/1/jpms-date08.pdf>
 --   <http://www.csi.ucd.ie/staff/jpms/talks/talksite/jpms-date08.pdf>
 --

--- a/src/ToySolver/SAT/PBO/UnsatBased.hs
+++ b/src/ToySolver/SAT/PBO/UnsatBased.hs
@@ -15,7 +15,7 @@
 -- * Vasco Manquinho Ruben Martins Inês Lynce
 --   Improving Unsatisfiability-based Algorithms for Boolean Optimization.
 --   Theory and Applications of Satisfiability Testing – SAT 2010, pp 181-193.
---   <http://dx.doi.org/10.1007/978-3-642-14186-7_16>
+--   <https://doi.org/10.1007/978-3-642-14186-7_16>
 --   <http://sat.inesc-id.pt/~ruben/papers/manquinho-sat10.pdf>
 --   <http://sat.inesc-id.pt/~ruben/talks/sat10-talk.pdf>
 --


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!