### PR TITLE
Revert "toysolver.cabal: use BSD-3-Clause instead of BSD3"

### DIFF
--- a/toysolver.cabal
+++ b/toysolver.cabal
@@ -1,6 +1,6 @@
 Name:		toysolver
 Version:	0.7.0
-License:	BSD-3-Clause
+License:	BSD3
 License-File:	COPYING
 Author:		Masahiro Sakai (masahiro.sakai@gmail.com)
 Maintainer:	masahiro.sakai@gmail.com


### PR DESCRIPTION
This reverts commit db3506740d4a4610fcab2213508bd40dd2e49af4.

Because it causes the following error:
```
Warning: toysolver.cabal:0:0: version with tags
Configuring toysolver-0.7.0...
Warning: 'license: BSD-3' is not a recognised license. The known licenses are:
GPL, GPL-2, GPL-3, LGPL, LGPL-2.1, LGPL-3, AGPL, AGPL-3, BSD2, BSD3, MIT, ISC,
MPL-2.0, Apache, Apache-2.0, PublicDomain, AllRightsReserved, OtherLicense
```