### PR TITLE
Use bytestring-encoding-0.1.1.0

### DIFF
--- a/stack-ghc-8.10.yaml
+++ b/stack-ghc-8.10.yaml
@@ -52,7 +52,7 @@ extra-deps:
 - OpenCL-1.0.3.4
 # - git: https://github.com/msakai/opencl.git
 #   commit: 80d0cb9d235819cd53e6a36d7a9258bc19d564ab
-- bytestring-encoding-0.1.0.0
+- bytestring-encoding-0.1.1.0
 - MIP-0.1.1.0
 
 # hack for avoiding haddock error of MemoTrie-0.6.4

--- a/stack-ghc-8.6.yaml
+++ b/stack-ghc-8.6.yaml
@@ -54,7 +54,7 @@ extra-deps:
 - OpenCL-1.0.3.4
 # - git: https://github.com/msakai/opencl.git
 #   commit: 80d0cb9d235819cd53e6a36d7a9258bc19d564ab
-- bytestring-encoding-0.1.0.0
+- bytestring-encoding-0.1.1.0
 - MIP-0.1.1.0
 
 # hack for avoiding haddock error of MemoTrie-0.6.4

--- a/stack-ghc-8.8.yaml
+++ b/stack-ghc-8.8.yaml
@@ -52,7 +52,7 @@ extra-deps:
 - OpenCL-1.0.3.4
 # - git: https://github.com/msakai/opencl.git
 #   commit: 80d0cb9d235819cd53e6a36d7a9258bc19d564ab
-- bytestring-encoding-0.1.0.0
+- bytestring-encoding-0.1.1.0
 - MIP-0.1.1.0
 
 # hack for avoiding haddock error of MemoTrie-0.6.4

--- a/stack-windows-i386.yaml
+++ b/stack-windows-i386.yaml
@@ -56,7 +56,7 @@ extra-deps:
 - OpenCL-1.0.3.4
 # - git: https://github.com/msakai/opencl.git
 #   commit: 80d0cb9d235819cd53e6a36d7a9258bc19d564ab
-- bytestring-encoding-0.1.0.0
+- bytestring-encoding-0.1.1.0
 - MIP-0.1.1.0
 
 # hack for avoiding haddock error of MemoTrie-0.6.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -52,7 +52,7 @@ extra-deps:
 - OpenCL-1.0.3.4
 # - git: https://github.com/msakai/opencl.git
 #   commit: 80d0cb9d235819cd53e6a36d7a9258bc19d564ab
-- bytestring-encoding-0.1.0.0
+- bytestring-encoding-0.1.1.0
 - MIP-0.1.1.0
 
 # hack for avoiding haddock error of MemoTrie-0.6.4

--- a/toysolver.cabal
+++ b/toysolver.cabal
@@ -132,7 +132,7 @@ Library
      base >=4.9 && <5,
      bytestring >=0.9.2.1 && <0.12,
      bytestring-builder,
-     bytestring-encoding,
+     bytestring-encoding >=0.1.1.0,
      case-insensitive,
      clock >=0.7.1,
      -- IntMap.restrictKeys and IntMap.withoutKeys require containers >=0.5.8


### PR DESCRIPTION
Because `bytestring-encoding-0.1.0.0` has a memory corruption bug.

https://github.com/msakai/bytestring-encoding/issues/2
https://github.com/msakai/bytestring-encoding/pull/3