### PR TITLE
Fix translation in ToySolver.Data.LA.FOL.toFOLExpr

### DIFF
--- a/src/ToySolver/Data/LA/FOL.hs
+++ b/src/ToySolver/Data/LA/FOL.hs
@@ -57,7 +57,7 @@ toFOLExpr e =
   case map f (LA.terms e) of
     []  -> Const 0
     [t] -> t
-    ts  -> foldr1 (*) ts
+    ts  -> foldr1 (+) ts
   where
     f (c,x)
       | x == LA.unitVar = Const c


### PR DESCRIPTION
The individual terms of an LA.Expr should be combined with +, not *.

I found this while playing with `FourierMotzkin.eliminateQuantifiers` - I'm happy to write a test if it's considered worthwhile.
