### PR TITLE
Fix linux/arm64 docker image build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,12 @@
 FROM haskell:8.10.7
+
+# https://github.com/haskell/docker-haskell/issues/81
+RUN if [ "$(dpkg-architecture --query DEB_BUILD_GNU_CPU)" = "aarch64" ]; then \
+      apt-get update && \
+      apt-get install -y --no-install-recommends libnuma-dev && \
+      apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    fi
+
 RUN cabal update && cabal install toysolver --flags="BuildToyFMF BuildSamplePrograms BuildMiscPrograms"
 WORKDIR /data
 CMD ["bash"]


### PR DESCRIPTION
Without this, it fails with the following error:

```
#6 105.3 Building executable 'alex' for alex-3.2.7.1..
#6 105.3 [ 1 of 22] Compiling Data.Ranged.Boundaries ( src/Data/Ranged/Boundaries.hs, dist/build/alex/alex-tmp/Data/Ranged/Boundaries.o )
#6 105.3 [ 2 of 22] Compiling Data.Ranged.Ranges ( src/Data/Ranged/Ranges.hs, dist/build/alex/alex-tmp/Data/Ranged/Ranges.o )
#6 105.3 [ 3 of 22] Compiling Data.Ranged.RangedSet ( src/Data/Ranged/RangedSet.hs, dist/build/alex/alex-tmp/Data/Ranged/RangedSet.o )
#6 105.3 [ 4 of 22] Compiling Data.Ranged      ( src/Data/Ranged.hs, dist/build/alex/alex-tmp/Data/Ranged.o )
#6 105.3 [ 5 of 22] Compiling Map              ( src/Map.hs, dist/build/alex/alex-tmp/Map.o )
#6 105.3 [ 6 of 22] Compiling Paths_alex       ( dist/build/alex/autogen/Paths_alex.hs, dist/build/alex/alex-tmp/Paths_alex.o )
#6 105.3 [ 7 of 22] Compiling Set              ( src/Set.hs, dist/build/alex/alex-tmp/Set.o )
#6 105.3 [ 8 of 22] Compiling DFS              ( src/DFS.hs, dist/build/alex/alex-tmp/DFS.o )
#6 105.3 [ 9 of 22] Compiling Sort             ( src/Sort.hs, dist/build/alex/alex-tmp/Sort.o )
#6 105.3 [10 of 22] Compiling UTF8             ( src/UTF8.hs, dist/build/alex/alex-tmp/UTF8.o )
#6 105.3 [11 of 22] Compiling CharSet          ( src/CharSet.hs, dist/build/alex/alex-tmp/CharSet.o )
#6 105.3 [12 of 22] Compiling Util             ( src/Util.hs, dist/build/alex/alex-tmp/Util.o )
#6 105.3 [13 of 22] Compiling AbsSyn           ( src/AbsSyn.hs, dist/build/alex/alex-tmp/AbsSyn.o )
#6 105.3 [14 of 22] Compiling ParseMonad       ( src/ParseMonad.hs, dist/build/alex/alex-tmp/ParseMonad.o )
#6 105.3 [15 of 22] Compiling Scan             ( src/Scan.hs, dist/build/alex/alex-tmp/Scan.o )
#6 105.3 [16 of 22] Compiling Parser           ( src/Parser.hs, dist/build/alex/alex-tmp/Parser.o )
#6 105.3 [17 of 22] Compiling Output           ( src/Output.hs, dist/build/alex/alex-tmp/Output.o )
#6 105.3 [18 of 22] Compiling NFA              ( src/NFA.hs, dist/build/alex/alex-tmp/NFA.o )
#6 105.3 [19 of 22] Compiling Info             ( src/Info.hs, dist/build/alex/alex-tmp/Info.o )
#6 105.3 [20 of 22] Compiling DFAMin           ( src/DFAMin.hs, dist/build/alex/alex-tmp/DFAMin.o )
#6 105.3 [21 of 22] Compiling DFA              ( src/DFA.hs, dist/build/alex/alex-tmp/DFA.o )
#6 105.3 [22 of 22] Compiling Main             ( src/Main.hs, dist/build/alex/alex-tmp/Main.o )
#6 105.3 Linking dist/build/alex/alex ...
#6 105.3 /usr/bin/ld.gold: error: cannot find -lnuma
#6 105.3 
#6 105.3 rts/posix/OSMem.c:370:0: error:
#6 105.3      error: undefined reference to 'mbind'
#6 105.3 
#6 105.3 rts/posix/OSMem.c:748:0: error:
#6 105.3      error: undefined reference to 'numa_num_configured_nodes'
#6 105.3 
#6 105.3 rts/posix/OSMem.c:758:0: error:
#6 105.3      error: undefined reference to 'numa_get_mems_allowed'
#6 105.3 
#6 105.3 rts/posix/OSMem.c:748:0: error:
#6 105.3      error: undefined reference to 'numa_num_configured_nodes'
#6 105.3 
#6 105.3 rts/posix/OSMem.c:763:0: error:
#6 105.3      error: undefined reference to 'numa_bitmask_free'
#6 105.3 
#6 105.3 rts/posix/OSMem.c:748:0: error:
#6 105.3      error: undefined reference to 'numa_num_configured_nodes'
#6 105.3 collect2: error: ld returned 1 exit status
#6 105.3 `gcc' failed in phase `Linker'. (Exit code: 1)
#6 105.3 cabal: Failed to build exe:alex from alex-3.2.7.1 (which is required by
#6 105.3 exe:toyfmf from toysolver-0.8.0). See the build log above for details.
```

See https://github.com/haskell/docker-haskell/issues/81