### PR TITLE
Cache stack-root from haskell/actions/setup instead of hard coded ~/.stack on GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,6 +68,7 @@ jobs:
           submodules: true
 
       - uses: haskell/actions/setup@v1
+        id: setup-haskell
         name: Setup Haskell
         with:
           ghc-version: ${{ matrix.ghc }}
@@ -89,7 +90,7 @@ jobs:
       - uses: actions/cache@v3
         name: Cache ~/.stack
         with:
-          path: ~/.stack
+          path: ${{ steps.setup-haskell.outputs.stack-root }}
           key: ${{ runner.os }}-${{ matrix.ghc }}-stack
 
       # https://github.com/commercialhaskell/stack/issues/5405


### PR DESCRIPTION
It fixes caching to work with Windows where we need to cache `c:\sr` instead of `~/.stack`.