### PR TITLE
Use patched version of tasty-th to read UTF-8 files on non-UTF-8 environments

### DIFF
--- a/stack-ghc-8.10.yaml
+++ b/stack-ghc-8.10.yaml
@@ -51,6 +51,9 @@ extra-deps:
 - sign-0.4.4
 - bytestring-encoding-0.1.1.0
 - MIP-0.1.1.0
+# Patched version of tasty-th for reading UTF-8 files on non UTF-8 environment.
+- git: https://github.com/msakai/tasty-th/
+  commit: ebbe5a79b3c7a537ceafc6291744c4d531bef63c
 
 # hack for avoiding haddock error of MemoTrie-0.6.4
 #- MemoTrie-0.6.7

--- a/stack-ghc-8.8.yaml
+++ b/stack-ghc-8.8.yaml
@@ -51,6 +51,9 @@ extra-deps:
 - sign-0.4.4
 - bytestring-encoding-0.1.1.0
 - MIP-0.1.1.0
+# Patched version of tasty-th for reading UTF-8 files on non UTF-8 environment.
+- git: https://github.com/msakai/tasty-th/
+  commit: ebbe5a79b3c7a537ceafc6291744c4d531bef63c
 
 # hack for avoiding haddock error of MemoTrie-0.6.4
 #- MemoTrie-0.6.7

--- a/stack-ghc-9.0.yaml
+++ b/stack-ghc-9.0.yaml
@@ -51,6 +51,9 @@ extra-deps:
 - sign-0.4.4
 - bytestring-encoding-0.1.1.0
 - MIP-0.1.1.0
+# Patched version of tasty-th for reading UTF-8 files on non UTF-8 environment.
+- git: https://github.com/msakai/tasty-th/
+  commit: ebbe5a79b3c7a537ceafc6291744c4d531bef63c
 
 # hack for avoiding haddock error of MemoTrie-0.6.4
 #- MemoTrie-0.6.7

--- a/stack-ghc-9.2.yaml
+++ b/stack-ghc-9.2.yaml
@@ -51,6 +51,9 @@ extra-deps:
 - sign-0.4.4
 - bytestring-encoding-0.1.1.0
 - MIP-0.1.1.0
+# Patched version of tasty-th for reading UTF-8 files on non UTF-8 environment.
+- git: https://github.com/msakai/tasty-th/
+  commit: ebbe5a79b3c7a537ceafc6291744c4d531bef63c
 
 # hack for avoiding haddock error of MemoTrie-0.6.4
 #- MemoTrie-0.6.7

--- a/stack-ghc-9.4.yaml
+++ b/stack-ghc-9.4.yaml
@@ -51,6 +51,9 @@ extra-deps:
 - sign-0.4.4
 - bytestring-encoding-0.1.2.0
 - MIP-0.1.1.0
+# Patched version of tasty-th for reading UTF-8 files on non UTF-8 environment.
+- git: https://github.com/msakai/tasty-th/
+  commit: ebbe5a79b3c7a537ceafc6291744c4d531bef63c
 
 # hack for avoiding haddock error of MemoTrie-0.6.4
 #- MemoTrie-0.6.7

--- a/stack-windows-i386.yaml
+++ b/stack-windows-i386.yaml
@@ -55,6 +55,9 @@ extra-deps:
 - sign-0.4.4
 - bytestring-encoding-0.1.1.0
 - MIP-0.1.1.0
+# Patched version of tasty-th for reading UTF-8 files on non UTF-8 environment.
+- git: https://github.com/msakai/tasty-th/
+  commit: ebbe5a79b3c7a537ceafc6291744c4d531bef63c
 
 # hack for avoiding haddock error of MemoTrie-0.6.4
 #- MemoTrie-0.6.7

--- a/stack.yaml
+++ b/stack.yaml
@@ -51,6 +51,9 @@ extra-deps:
 - sign-0.4.4
 - bytestring-encoding-0.1.1.0
 - MIP-0.1.1.0
+# Patched version of tasty-th for reading UTF-8 files on non UTF-8 environment.
+- git: https://github.com/msakai/tasty-th/
+  commit: ebbe5a79b3c7a537ceafc6291744c4d531bef63c
 
 # hack for avoiding haddock error of MemoTrie-0.6.4
 #- MemoTrie-0.6.7


### PR DESCRIPTION
patching commit: https://github.com/msakai/tasty-th/commit/ebbe5a79b3c7a537ceafc6291744c4d531bef63c

PR to the original repository: https://github.com/bennofs/tasty-th/pull/13