### PR TITLE
GitHub Actions: trigger CI only on 'master' branch, tags, and pull requests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,11 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+
 name: build
 jobs:
   build:


### PR DESCRIPTION
We do not want CI to be performed twice for a pull request from the same repository: once for a push to a branch and once for a pull request.