### PR TITLE
Add --dump-info option to toyconvert

### DIFF
--- a/src/ToySolver/Converter/MIP2PB.hs
+++ b/src/ToySolver/Converter/MIP2PB.hs
@@ -57,11 +57,11 @@ data MIP2PBInfo = MIP2PBInfo (Map MIP.Var Integer.Expr) !Integer
   deriving (Eq, Show)
 
 instance Transformer MIP2PBInfo where
-  type Source MIP2PBInfo = Map MIP.Var Integer
+  type Source MIP2PBInfo = Map MIP.Var Rational
   type Target MIP2PBInfo = SAT.Model
 
 instance BackwardTransformer MIP2PBInfo where
-  transformBackward (MIP2PBInfo vmap _d) m = fmap (Integer.eval m) vmap
+  transformBackward (MIP2PBInfo vmap _d) m = fmap (toRational . Integer.eval m) vmap
 
 instance ObjValueTransformer MIP2PBInfo where
   type SourceObjValue MIP2PBInfo = Rational

--- a/toysolver.cabal
+++ b/toysolver.cabal
@@ -551,6 +551,7 @@ Executable toyconvert
     base,
     bytestring,
     bytestring-builder,
+    containers,
     data-default-class,
     filepath,
     MIP,


### PR DESCRIPTION
Information is dumped by using the `Show` instance, but I'll change it to JSON or something later.