### PR TITLE
Explicitly specify base bounds on all sections

### DIFF
--- a/toysolver.cabal
+++ b/toysolver.cabal
@@ -387,7 +387,7 @@ Executable toysolver
   HS-Source-Dirs: app
   Build-Depends:
     array,
-    base,
+    base >=4.12 && <4.21,
     containers,
     data-default-class,
     filepath,
@@ -412,7 +412,7 @@ Executable toysat
   HS-Source-Dirs: app/toysat
   Build-Depends:
     array,
-    base,
+    base >=4.12 && <4.21,
     bytestring,
     containers,
     clock,
@@ -450,7 +450,7 @@ Foreign-Library     toysat-ipasir
   if os(Linux)
     ld-options: -Wl,--version-script=app/toysat-ipasir/ipasir.map
   build-depends:
-    base,
+    base >=4.12 && <4.21,
     containers,
     toysolver
   hs-source-dirs:   app/toysat-ipasir
@@ -476,7 +476,7 @@ Executable toysmt
      Smtlib.Syntax.Syntax,
      Smtlib.Syntax.ShowSL
   Build-Depends:
-    base,
+    base >=4.12 && <4.21,
     containers,
     -- TODO: remove intern dependency
     intern,
@@ -503,7 +503,7 @@ Executable toyqbf
   Main-is: toyqbf.hs
   HS-Source-Dirs: app
   Build-Depends:
-    base,
+    base >=4.12 && <4.21,
     containers,
     data-default-class,
     optparse-applicative,
@@ -524,7 +524,7 @@ Executable toyfmf
   HS-Source-Dirs: app
   If flag(BuildToyFMF)
     Build-Depends:
-      base,
+      base >=4.12 && <4.21,
       containers,
       intern,
       logic-TPTP >=0.4.6.0 && <0.7,
@@ -547,7 +547,7 @@ Executable toyconvert
   HS-Source-Dirs: app
   Build-Depends:
     aeson,
-    base,
+    base >=4.12 && <4.21,
     bytestring,
     bytestring-builder,
     containers,
@@ -586,7 +586,7 @@ Executable sudoku
   HS-Source-Dirs: samples/programs/sudoku
   Build-Depends:
     array,
-    base,
+    base >=4.12 && <4.21,
     toysolver
   Default-Language: Haskell2010
   Other-Extensions: CPP
@@ -603,7 +603,7 @@ Executable nonogram
   HS-Source-Dirs: samples/programs/nonogram
   Build-Depends:
     array,
-    base,
+    base >=4.12 && <4.21,
     containers,
     toysolver
   Default-Language: Haskell2010
@@ -622,7 +622,7 @@ Executable nqueens
   HS-Source-Dirs: samples/programs/nqueens
   Build-Depends:
     array,
-    base,
+    base >=4.12 && <4.21,
     toysolver
   Default-Language: Haskell2010
   Other-Extensions: CPP
@@ -640,7 +640,7 @@ Executable numberlink
   HS-Source-Dirs: samples/programs/numberlink
   Build-Depends:
     array,
-    base,
+    base >=4.12 && <4.21,
     bytestring,
     containers,
     data-default-class,
@@ -662,7 +662,7 @@ Executable knapsack
   Main-is: knapsack.hs
   HS-Source-Dirs: samples/programs/knapsack
   Build-Depends:
-    base,
+    base >=4.12 && <4.21,
     toysolver
   Default-Language: Haskell2010
   Other-Extensions: CPP
@@ -680,7 +680,7 @@ Executable assign
   HS-Source-Dirs: samples/programs/assign
   Build-Depends:
     attoparsec,
-    base,
+    base >=4.12 && <4.21,
     bytestring,
     containers,
     toysolver,
@@ -700,7 +700,7 @@ Executable shortest-path
   Main-is: shortest-path.hs
   HS-Source-Dirs: samples/programs/shortest-path
   Build-Depends:
-    base,
+    base >=4.12 && <4.21,
     bytestring,
     containers,
     unordered-containers,
@@ -720,7 +720,7 @@ Executable htc
   Main-is: htc.hs
   HS-Source-Dirs: samples/programs/htc
   Build-Depends:
-    base,
+    base >=4.12 && <4.21,
     containers,
     toysolver
   Default-Language: Haskell2010
@@ -738,7 +738,7 @@ Executable svm2lp
   Main-is: svm2lp.hs
   HS-Source-Dirs: samples/programs/svm2lp
   Build-Depends:
-    base,
+    base >=4.12 && <4.21,
     containers,
     data-default-class,
     MIP,
@@ -761,7 +761,7 @@ Executable survey-propagation
   Main-is: survey-propagation.hs
   HS-Source-Dirs: samples/programs/survey-propagation
   Build-Depends:
-    base,
+    base >=4.12 && <4.21,
     data-default-class,
     toysolver
   Default-Language: Haskell2010
@@ -779,7 +779,7 @@ Executable probsat
   Main-is: probsat.hs
   HS-Source-Dirs: samples/programs/probsat
   Build-Depends:
-    base,
+    base >=4.12 && <4.21,
     clock,
     data-default-class,
     mwc-random,
@@ -803,7 +803,7 @@ Executable pigeonhole
   Main-is: pigeonhole.hs
   HS-Source-Dirs: app
   Build-Depends:
-    base,
+    base >=4.12 && <4.21,
     bytestring,
     containers,
     pseudo-boolean,
@@ -824,7 +824,7 @@ Executable maxsatverify
   HS-Source-Dirs: app
   Build-Depends:
     array,
-    base,
+    base >=4.12 && <4.21,
     toysolver
   Default-Language: Haskell2010
   Other-Extensions: CPP
@@ -842,7 +842,7 @@ Executable pbverify
   HS-Source-Dirs: app
   Build-Depends:
     array,
-    base,
+    base >=4.12 && <4.21,
     pseudo-boolean,
     toysolver
   Default-Language: Haskell2010
@@ -861,7 +861,7 @@ Test-suite TestPolynomial
   HS-Source-Dirs:    test
   Main-is:           TestPolynomial.hs
   Build-depends:
-    base,
+    base >=4.12 && <4.21,
     containers,
     data-interval,
     finite-field >=0.7.0 && <1.0.0,
@@ -925,7 +925,7 @@ Test-suite TestSuite
   Build-depends:
     aeson,
     array,
-    base,
+    base >=4.12 && <4.21,
     bytestring,
     bytestring-builder,
     containers,
@@ -972,7 +972,7 @@ Benchmark BenchmarkSATLIB
   main-is:          BenchmarkSATLIB.hs
   build-depends:
     array,
-    base,
+    base >=4.12 && <4.21,
     criterion >=1.0 && <1.7,
     data-default-class,
     toysolver
@@ -983,7 +983,7 @@ Benchmark BenchmarkKnapsack
   hs-source-dirs:   benchmarks
   main-is:          BenchmarkKnapsack.hs
   build-depends:
-    base,
+    base >=4.12 && <4.21,
     criterion >=1.0 && <1.7,
     toysolver
   Default-Language: Haskell2010
@@ -993,7 +993,7 @@ Benchmark BenchmarkSubsetSum
   hs-source-dirs:   benchmarks
   main-is:          BenchmarkSubsetSum.hs
   build-depends:
-    base,
+    base >=4.12 && <4.21,
     criterion >=1.0 && <1.7,
     toysolver,
     vector


### PR DESCRIPTION
This is to avoid the following error when uploading a package to Hackage:

```
Error: [S-6108]
       unhandled status code: 400
       Upload failed on toysolver-0.9.0.tar.gz
       "Error: Invalid package\n\n[missing-bounds-important] The dependency 'build-depends: base' does not specify an upper bound on the version number. Each major release of the 'base' package changes the API in various ways and most packages will need some changes to compile with it. The recommended practice is to specify an upper bound on the version of the 'base' package. This ensures your package will continue to build when a new major version of the 'base' package is released. If you are not sure what upper bound to use then use the next  major version. For example if you have tested your package with 'base' version 4.5 and 4.6 then use 'build-depends: base >= 4.5 && < 4.7'.\n"
```

Duplication should be eliminated later by using common stanzas (c.f. #151).