### PR TITLE
Change ToySolver.SAT.Encoder.Integer to encode integer variables without introducing <= constraints

### DIFF
--- a/src/ToySolver/SAT/Encoder/Integer.hs
+++ b/src/ToySolver/SAT/Encoder/Integer.hs
@@ -42,10 +42,9 @@ newVar enc lo hi
   | otherwise = do
       let hi' = hi - lo
           bitWidth = head $ [w | w <- [1..], let mx = 2 ^ w - 1, hi' <= mx]
-      vs <- SAT.newVars enc bitWidth
-      let xs = zip (iterate (2*) 1) vs
-      SAT.addPBAtMost enc xs hi'
-      return $ Expr $ [(lo,[]) | lo /= 0] ++ [(c,[x]) | (c,x) <- xs]
+      vs <- SAT.newVars enc (bitWidth - 1)
+      v <- SAT.newVar enc
+      return $ Expr $ [(lo,[]) | lo /= 0] ++ [(c,[x]) | (c,x) <- zip (iterate (2*) 1) vs] ++ [(hi' - (2 ^ (bitWidth - 1) - 1), [v])]
 
 instance AdditiveGroup Expr where
   Expr xs1 ^+^ Expr xs2 = Expr (xs1++xs2)


### PR DESCRIPTION
When we encode a bounded integer variable (with lower bound $l$ and upper bound $u$) into a set of boolean variables, we use

$$
x = \sum_{i=0}^{m-1} 2^i b_i + l
$$

with a constraint

$$
 \sum_{i=0}^{m-1} 2^i b_i \le u - l.
$$

But I read https://jij-inc.github.io/ommx/ja/release_note/ommx-1.9.0.html, and it uses the following encoding

$$
x = \sum_{i=0}^{m-2} 2^i b_i + (u - l - 2^{m-1} + 1) b_{m-1} + l
$$

without constraints.

This PR adopts this encoding.