### PR TITLE
CI: Pass --ghc-options=-j to stack when builing toysolver package

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Build
         shell: bash
-        run: stack build --test --no-run-tests --bench --no-run-benchmarks ${{ matrix.stack_args }} ${{ matrix.flags }}
+        run: stack build --test --no-run-tests --bench --no-run-benchmarks --ghc-options=-j ${{ matrix.stack_args }} ${{ matrix.flags }}
 
       - name: Test
         shell: bash


### PR DESCRIPTION
We don't pass --ghc-options=-j when we build dependencies, because parallelism is already exploited by building multiple dependencies in parallel.
https://docs.haskellstack.org/en/stable/configure/global_flags/#-jobs-or-j-option