### PR TITLE
Use Cauchy's bounds instead of Lagrange's bounds as the bounds for all roots

### DIFF
--- a/src/ToySolver/Data/AlgebraicNumber/Sturm.hs
+++ b/src/ToySolver/Data/AlgebraicNumber/Sturm.hs
@@ -1,7 +1,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  ToySolver.Data.AlgebraicNumber.Sturm
--- Copyright   :  (c) Masahiro Sakai 2012
+-- Copyright   :  (c) Masahiro Sakai 2012-2026
 -- License     :  BSD-style
 --
 -- Maintainer  :  masahiro.sakai@gmail.com
@@ -95,14 +95,16 @@ countChanges (x:xs) = go x xs 0
       | otherwise = go x2 xs (r+1)
 
 -- | Closed interval that contains all real roots of a given polynomial.
--- 根の限界
--- <http://aozoragakuen.sakura.ne.jp/taiwa/taiwaNch02/node26.html>
+--
+-- Currently Cauchy's bounds is used.
+--
+-- <https://en.wikipedia.org/wiki/Geometrical_properties_of_polynomial_roots>
 bounds :: UPolynomial Rational -> (Rational, Rational)
 bounds p = (-m, m)
   where
-    m = if p==0
+    m = if P.deg p == 0
         then 0
-        else max 1 (sum [abs (c/s) | (c,_) <- P.terms p] - 1)
+        else 1 + maximum (0 : [abs (c/s) | (c,xs) <- P.terms p, P.deg xs /= P.deg p])
     s = P.lc P.nat p
 
 boundInterval :: UPolynomial Rational -> Interval Rational -> Interval Rational

--- a/src/ToySolver/Data/AlgebraicNumber/Sturm.hs
+++ b/src/ToySolver/Data/AlgebraicNumber/Sturm.hs
@@ -31,6 +31,8 @@ module ToySolver.Data.AlgebraicNumber.Sturm
   , narrow'
   , approx
   , approx'
+
+  , cauchysBounds
   ) where
 
 import Data.Maybe
@@ -96,15 +98,20 @@ countChanges (x:xs) = go x xs 0
 
 -- | Closed interval that contains all real roots of a given polynomial.
 --
--- Currently Cauchy's bounds is used.
---
--- <https://en.wikipedia.org/wiki/Geometrical_properties_of_polynomial_roots>
+-- Currently Cauchy's bounds ('cauchysBounds') is used.
 bounds :: UPolynomial Rational -> (Rational, Rational)
 bounds p = (-m, m)
   where
-    m = if P.deg p == 0
-        then 0
-        else 1 + maximum (0 : [abs (c/s) | (c,xs) <- P.terms p, P.deg xs /= P.deg p])
+    m = cauchysBounds p
+
+-- | Cauchy's upper bounds for the magnitudes of all roots
+--
+-- <https://en.wikipedia.org/wiki/Geometrical_properties_of_polynomial_roots>
+cauchysBounds :: UPolynomial Rational -> Rational
+cauchysBounds p
+  | P.deg p == 0 = 0
+  | otherwise = 1 + maximum (0 : [abs (c/s) | (c,xs) <- P.terms p, P.deg xs /= P.deg p])
+  where
     s = P.lc P.nat p
 
 boundInterval :: UPolynomial Rational -> Interval Rational -> Interval Rational

--- a/test/Test/AReal.hs
+++ b/test/Test/AReal.hs
@@ -286,6 +286,38 @@ case_separate = do
     intervals = Sturm.separate p
     vals = [-1.21465, -0.334734, 1.38879]
 
+case_cauchysBounds_constant = do
+  m @?= 0
+  Sturm.numRoots p (Finite (-m) <=..<= Finite m) @?= 0
+  where
+    p = 1
+    m = Sturm.cauchysBounds p
+
+case_cauchysBounds_linear_1 = do
+  m @?= (1 + 1/2)
+  Sturm.numRoots p (Finite (-m) <=..<= Finite m) @?= 1
+  where
+    x = P.var X
+    p = 2*x + 1
+    m = Sturm.cauchysBounds p
+
+case_cauchysBounds_linear_2 = do
+  m @?= 1
+  Sturm.numRoots p (Finite (-m) <=..<= Finite m) @?= 1
+  where
+    x = P.var X
+    p = 2*x
+    m = Sturm.cauchysBounds p
+
+-- https://x.com/Pajoca_/status/1969404597845573723
+case_cauchysBounds_pajoca = do
+  m @?= 3
+  Sturm.numRoots p (Finite (-m) <=..<= Finite m) @?= 1
+  where
+    x = P.var X
+    p = 2*x^3 - 3*x^2 - 4
+    m = Sturm.cauchysBounds p
+
 ------------------------------------------------------------------------
 -- Test harness
 


### PR DESCRIPTION
Cauchy's bounds are tighter than Lagrange's bounds for most cases. Therefore, root separation is expected to be more efficient.

https://en.wikipedia.org/wiki/Geometrical_properties_of_polynomial_roots

> Lagrange's bound is sharper (smaller) than Cauchy's bound only when 1 is larger than the sum of all  ${\displaystyle \left|{\frac {a_{i}}{a_{n}}}\right|}$ but the largest. This is relatively rare in practice, and explains why Cauchy's bound is more widely used than Lagrange's.