### PR TITLE
Stop deriving Typeable

### DIFF
--- a/src/ToySolver/Combinatorial/HittingSet/HTCBDD.hs
+++ b/src/ToySolver/Combinatorial/HittingSet/HTCBDD.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# OPTIONS_GHC -Wall #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 -----------------------------------------------------------------------------
@@ -34,7 +33,6 @@ import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Typeable
 import System.Exit
 import System.IO
 import System.IO.Temp
@@ -69,7 +67,7 @@ instance Default Options where
     }
 
 data Failure = Failure !Int
-  deriving (Show, Typeable)
+  deriving (Show)
 
 instance Exception Failure
 

--- a/src/ToySolver/Combinatorial/HittingSet/SHD.hs
+++ b/src/ToySolver/Combinatorial/HittingSet/SHD.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# OPTIONS_GHC -Wall #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 -----------------------------------------------------------------------------
@@ -33,7 +32,6 @@ import Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Typeable
 import System.Exit
 import System.IO
 import System.IO.Temp
@@ -60,7 +58,7 @@ instance Default Options where
     }
 
 data Failure = Failure !Int
-  deriving (Show, Typeable)
+  deriving (Show)
 
 instance Exception Failure
 

--- a/src/ToySolver/Data/BoolExpr.hs
+++ b/src/ToySolver/Data/BoolExpr.hs
@@ -44,7 +44,7 @@ data BoolExpr a
   | Imply (BoolExpr a) (BoolExpr a)
   | Equiv (BoolExpr a) (BoolExpr a)
   | ITE (BoolExpr a) (BoolExpr a) (BoolExpr a)
-  deriving (Eq, Ord, Show, Read, Typeable, Data)
+  deriving (Eq, Ord, Show, Read, Data)
 
 instance Functor BoolExpr where
   fmap = fmapDefault

--- a/src/ToySolver/Data/BoolRing.hs
+++ b/src/ToySolver/Data/BoolRing.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_HADDOCK show-extensions #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -----------------------------------------------------------------------------
 -- |

--- a/src/ToySolver/Data/BoolRing.hs
+++ b/src/ToySolver/Data/BoolRing.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_HADDOCK show-extensions #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -----------------------------------------------------------------------------
 -- |
@@ -17,11 +16,10 @@ module ToySolver.Data.BoolRing
   ) where
 
 import Data.Ix
-import Data.Typeable
 import Data.Generics
 
 newtype BoolRing = BoolRing Bool
-  deriving (Eq, Show, Read, Enum, Ord, Ix, Data, Typeable)
+  deriving (Eq, Show, Read, Enum, Ord, Ix, Data)
 
 instance Num BoolRing where
   BoolRing a + BoolRing b = BoolRing (a /= b) -- xor

--- a/src/ToySolver/Data/Polynomial/Base.hs
+++ b/src/ToySolver/Data/Polynomial/Base.hs
@@ -176,7 +176,7 @@ class Degree t where
 
 -- | Polynomial over commutative ring r
 newtype Polynomial r v = Polynomial{ coeffMap :: Map (Monomial v) r }
-  deriving (Eq, Ord, Typeable)
+  deriving (Eq, Ord)
 
 instance (Eq k, Num k, Ord v) => Num (Polynomial k v) where
   (+)      = plus
@@ -619,7 +619,7 @@ type UPolynomial r = Polynomial r X
 
 -- | Variable "x"
 data X = X
-  deriving (Eq, Ord, Bounded, Enum, Show, Read, Typeable, Data)
+  deriving (Eq, Ord, Bounded, Enum, Show, Read, Data)
 
 instance NFData X where
    rnf a = a `seq` ()
@@ -782,7 +782,7 @@ tintegral (c,xs) x =
 
 -- | Monic monomials
 newtype Monomial v = Monomial{ mindicesMap :: Map v Integer }
-  deriving (Eq, Ord, Typeable)
+  deriving (Eq, Ord)
 
 type UMonomial = Monomial X
 

--- a/src/ToySolver/FileFormat/Base.hs
+++ b/src/ToySolver/FileFormat/Base.hs
@@ -1,7 +1,6 @@
 {-# OPTIONS_GHC -Wall #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 -- |
@@ -33,7 +32,6 @@ import Control.Monad.IO.Class
 import qualified Data.ByteString.Lazy.Char8 as BS
 import Data.ByteString.Builder hiding (writeFile)
 import Data.Char
-import Data.Typeable
 import System.IO hiding (readFile, writeFile)
 
 #ifdef WITH_ZLIB
@@ -52,7 +50,7 @@ class FileFormat a where
 
 -- | 'ParseError' represents a parse error and it wraps a error message.
 data ParseError = ParseError String
-  deriving (Show, Typeable)
+  deriving (Show)
 
 instance Exception ParseError
 

--- a/src/ToySolver/SAT/Solver/CDCL.hs
+++ b/src/ToySolver/SAT/Solver/CDCL.hs
@@ -2,7 +2,6 @@
 {-# OPTIONS_HADDOCK show-extensions #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecursiveDo #-}
@@ -163,7 +162,6 @@ import qualified Data.Set as Set
 import ToySolver.Internal.Data.IOURef
 import qualified ToySolver.Internal.Data.IndexedPriorityQueue as PQ
 import qualified ToySolver.Internal.Data.Vec as Vec
-import Data.Typeable
 import System.Clock
 import qualified System.Random.MWC as Rand
 import Text.Printf
@@ -1173,12 +1171,12 @@ solve_ solver = do
       Left m -> m
 
 data BudgetExceeded = BudgetExceeded
-  deriving (Show, Typeable)
+  deriving (Show)
 
 instance Exception BudgetExceeded
 
 data Canceled = Canceled
-  deriving (Show, Typeable)
+  deriving (Show)
 
 instance Exception Canceled
 

--- a/src/ToySolver/SAT/Solver/SLS/ProbSAT.hs
+++ b/src/ToySolver/SAT/Solver/SLS/ProbSAT.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wall #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
@@ -58,7 +57,6 @@ import Data.IORef
 import Data.Maybe
 import Data.Sequence ((|>))
 import qualified Data.Sequence as Seq
-import Data.Typeable
 import Data.Word
 import System.Clock
 import qualified System.Random.MWC as Rand
@@ -375,7 +373,7 @@ rand n gen
       return $ (a `shiftL` 32) .|. toInteger b
 
 data Finished = Finished
-  deriving (Show, Typeable)
+  deriving (Show)
 
 instance Exception Finished
 

--- a/src/ToySolver/SMT.hs
+++ b/src/ToySolver/SMT.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_HADDOCK show-extensions #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -90,7 +89,6 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.String
 import qualified Data.Text as T
-import Data.Typeable
 import Data.VectorSpace
 
 import ToySolver.Data.Delta
@@ -200,7 +198,7 @@ data FDef
 data Exception
   = Error String
   | Unsupported
-  deriving (Show, Typeable)
+  deriving (Show)
 
 instance E.Exception Exception
 


### PR DESCRIPTION
Since GHC 7.10 instances of Typeable class are automatically derived and deriving them manually causes warning.