### PR TITLE
Stop supporting old versions of libraries (aeson, array, hashable, optparse-applicative)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,14 +21,14 @@ jobs:
             os: ubuntu-latest
             stack_yaml: 'stack-ghc-9.12.yaml'
             stack_args: ''
-            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms --flag toysolver:optparse-applicative-018'
+            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms'
             platform: linux-x86_64
 
           - ghc: '9.10.3'
             os: ubuntu-latest
             stack_yaml: 'stack-ghc-9.10.yaml'
             stack_args: '--haddock --no-haddock-deps'
-            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms --flag toysolver:optparse-applicative-018'
+            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms'
             platform: linux-x86_64
             release: true
           # Use GHC 9.10 because hashtables-1.3.1 failed to compile on ghc-musl:9.8.4
@@ -36,7 +36,7 @@ jobs:
             os: ubuntu-latest
             stack_yaml: 'stack-ghc-9.10.yaml'
             stack_args: '--docker --docker-image "quay.io/benz0li/ghc-musl:9.10.3"'
-            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms --flag toysolver:optparse-applicative-018 --flag toysolver:LinuxStatic'
+            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms --flag toysolver:LinuxStatic'
             platform: linux-x86_64-static
             release: true
           # Use GHC 9.10 on windows to avoid the issue with foreign-library
@@ -45,21 +45,21 @@ jobs:
             os: windows-latest
             stack_yaml: 'stack-ghc-9.10.yaml'
             stack_args: ''
-            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms --flag toysolver:optparse-applicative-018'
+            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms'
             platform: win64
             release: true
           - ghc: '9.10.3'
             os: macos-latest
             stack_yaml: 'stack-ghc-9.10.yaml'
             stack_args: ''
-            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms --flag toysolver:optparse-applicative-018'
+            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms'
             platform: macos-aarch64
             release: true
           - ghc: '9.10.3'
             os: macos-latest
             stack_yaml: 'stack-ghc-9.10.yaml'
             stack_args: ''
-            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms --flag toysolver:optparse-applicative-018'
+            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms'
             platform: macos-x86_64
             release: true
 
@@ -67,7 +67,7 @@ jobs:
             os: ubuntu-latest
             stack_yaml: 'stack-ghc-9.8.yaml'
             stack_args: '--coverage'
-            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms --flag toysolver:optparse-applicative-018'
+            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms'
             platform: linux-x86_64
             coveralls: true
 
@@ -75,7 +75,7 @@ jobs:
             os: ubuntu-latest
             stack_yaml: 'stack-ghc-9.6.yaml'
             stack_args: ''
-            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms --flag toysolver:optparse-applicative-018'
+            flags: '--flag toysolver:BuildToyFMF --flag toysolver:BuildSamplePrograms --flag toysolver:BuildMiscPrograms'
             platform: linux-x86_64
 
     steps:

--- a/app/toyconvert.hs
+++ b/app/toyconvert.hs
@@ -35,13 +35,8 @@ import Options.Applicative hiding (info)
 import qualified Options.Applicative
 import System.IO
 import System.Exit
-#if MIN_VERSION_optparse_applicative(0,18,0)
 import Prettyprinter ((<+>))
 import qualified Prettyprinter as PP
-#else
-import Text.PrettyPrint.ANSI.Leijen ((<+>))
-import qualified Text.PrettyPrint.ANSI.Leijen as PP
-#endif
 
 import qualified Data.PseudoBoolean as PBFile
 import qualified Numeric.Optimization.MIP as MIP
@@ -243,8 +238,6 @@ parserInfo = Options.Applicative.info (helper <*> versionOption <*> optionsParse
       <> long "version"
       <> help "Show version"
 
-#if MIN_VERSION_optparse_applicative(0,18,0)
-
 supportedFormatsDoc :: PP.Doc ann
 supportedFormatsDoc =
   PP.vsep
@@ -254,20 +247,6 @@ supportedFormatsDoc =
       , PP.pretty "output:" <+> (PP.align $ PP.fillSep $ map PP.pretty $ words ".cnf .wcnf .opb .wbo .lsp .lp .mps .smp .smt2 .ys .qubo")
       ]
   ]
-
-#else
-
-supportedFormatsDoc :: PP.Doc
-supportedFormatsDoc =
-  PP.vsep
-  [ PP.text "Supported formats:"
-  , PP.indent 2 $ PP.vsep
-      [ PP.text "input:"  <+> (PP.align $ PP.fillSep $ map PP.text $ words ".cnf .wcnf .opb .wbo .gcnf .lp .mps .qubo")
-      , PP.text "output:" <+> (PP.align $ PP.fillSep $ map PP.text $ words ".cnf .wcnf .opb .wbo .lsp .lp .mps .smp .smt2 .ys .qubo")
-      ]
-  ]
-
-#endif
 
 data Trail sol where
   Trail :: (Transformer a, J.ToJSON a) => a -> Trail (Target a)

--- a/src/ToySolver/Converter/MIP.hs
+++ b/src/ToySolver/Converter/MIP.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -Wall #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -47,9 +46,7 @@ import Control.Monad.Trans
 import Control.Monad.Trans.Except
 import qualified Data.Aeson as J
 import qualified Data.Aeson.Types as J
-#if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.Key as Key
-#endif
 import Data.Aeson ((.=), (.:))
 import Data.Array.IArray
 import Data.Default.Class
@@ -194,16 +191,10 @@ instance J.ToJSON WBO2IPInfo where
     [ "type" .= ("WBO2IPInfo" :: J.Value)
     , "num_original_variables" .= nv
     , "relax_variables" .= J.object
-        [ toKey (MIP.varName v) .= jPBConstraint constr
+        [ Key.fromText (MIP.varName v) .= jPBConstraint constr
         | (v, constr) <- relaxVariables
         ]
     ]
-    where
-#if MIN_VERSION_aeson(2,0,0)
-      toKey = Key.fromText
-#else
-      toKey = id
-#endif
 
 instance J.FromJSON WBO2IPInfo where
   parseJSON =
@@ -384,11 +375,11 @@ instance J.ToJSON IP2PBInfo where
     J.object
     [ "type" .= ("IP2PBInfo" :: J.Value)
     , "substitutions" .= J.object
-        [ toKey (MIP.varName v) .= jPBSum s
+        [ Key.fromText (MIP.varName v) .= jPBSum s
         | (v, Integer.Expr s) <- Map.toList vmap
         ]
     , "nonzero_indicators" .= J.object
-        [ toKey (MIP.varName v) .= (jLitName lit :: J.Value)
+        [ Key.fromText (MIP.varName v) .= (jLitName lit :: J.Value)
         | (v, lit) <- Map.toList nonZeroTable
         ]
     , "objective_function_scale_factor" .=
@@ -397,12 +388,6 @@ instance J.ToJSON IP2PBInfo where
         , "denominator" .= denominator s
         ]
     ]
-    where
-#if MIN_VERSION_aeson(2,0,0)
-      toKey = Key.fromText
-#else
-      toKey = id
-#endif
 
 instance J.FromJSON IP2PBInfo where
   parseJSON = withTypedObject "IP2PBInfo" $ \obj -> do

--- a/src/ToySolver/SAT/Solver/CDCL.hs
+++ b/src/ToySolver/SAT/Solver/CDCL.hs
@@ -142,9 +142,6 @@ import Control.Exception
 import Data.Array.IO
 import Data.Array.Unsafe (unsafeFreeze)
 import Data.Array.Base (unsafeRead, unsafeWrite)
-#if !MIN_VERSION_hashable(1,4,3)
-import Data.Bits (xor) -- for defining 'combine' function
-#endif
 import Data.Coerce
 import Data.Default.Class
 import Data.Either
@@ -3623,16 +3620,6 @@ shift ref = do
   (x:xs) <- readIORef ref
   writeIORef ref xs
   return x
-
-#if !MIN_VERSION_hashable(1,4,3)
-
-defaultHashWithSalt :: Hashable a => Int -> a -> Int
-defaultHashWithSalt salt x = salt `combine` hash x
-  where
-    combine :: Int -> Int -> Int
-    combine h1 h2 = (h1 * 16777619) `xor` h2
-
-#endif
 
 {--------------------------------------------------------------------
   debug

--- a/src/ToySolver/SAT/Solver/SLS/ProbSAT.hs
+++ b/src/ToySolver/SAT/Solver/SLS/ProbSAT.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -528,16 +527,6 @@ walksat solver opt cb p = do
   return ()
 
 -- -------------------------------------------------------------------
-
-#if !MIN_VERSION_array(0,5,6)
-
-{-# INLINE modifyArray #-}
-modifyArray :: (MArray a e m, Ix i) => a i e -> i -> (e -> e) -> m ()
-modifyArray a i f = do
-  e <- readArray a i
-  writeArray a i (f e)
-
-#endif
 
 {-# INLINE forAssocsM_ #-}
 forAssocsM_ :: (IArray a e, Monad m) => a Int e -> ((Int,e) -> m ()) -> m ()

--- a/stack-ghc-9.10.yaml
+++ b/stack-ghc-9.10.yaml
@@ -55,9 +55,7 @@ extra-deps:
   commit: ebbe5a79b3c7a537ceafc6291744c4d531bef63c
 
 # Override default flag values for local packages and extra-deps
-flags:
-  toysolver:
-    optparse-applicative-018: true
+flags: {}
 
 # Extra package databases containing global packages
 extra-package-dbs: []

--- a/stack-ghc-9.12.yaml
+++ b/stack-ghc-9.12.yaml
@@ -55,9 +55,7 @@ extra-deps:
   commit: ebbe5a79b3c7a537ceafc6291744c4d531bef63c
 
 # Override default flag values for local packages and extra-deps
-flags:
-  toysolver:
-    optparse-applicative-018: true
+flags: {}
 
 # Extra package databases containing global packages
 extra-package-dbs: []

--- a/stack-ghc-9.6.yaml
+++ b/stack-ghc-9.6.yaml
@@ -55,9 +55,7 @@ extra-deps:
   commit: ebbe5a79b3c7a537ceafc6291744c4d531bef63c
 
 # Override default flag values for local packages and extra-deps
-flags:
-  toysolver:
-    optparse-applicative-018: true
+flags: {}
 
 # Extra package databases containing global packages
 extra-package-dbs: []

--- a/stack-ghc-9.8.yaml
+++ b/stack-ghc-9.8.yaml
@@ -55,9 +55,7 @@ extra-deps:
   commit: ebbe5a79b3c7a537ceafc6291744c4d531bef63c
 
 # Override default flag values for local packages and extra-deps
-flags:
-  toysolver:
-    optparse-applicative-018: true
+flags: {}
 
 # Extra package databases containing global packages
 extra-package-dbs: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -55,9 +55,7 @@ extra-deps:
   commit: ebbe5a79b3c7a537ceafc6291744c4d531bef63c
 
 # Override default flag values for local packages and extra-deps
-flags:
-  toysolver:
-    optparse-applicative-018: true
+flags: {}
 
 # Extra package databases containing global packages
 extra-package-dbs: []

--- a/toysolver.cabal
+++ b/toysolver.cabal
@@ -110,11 +110,6 @@ Flag ExtraBoundsChecking
   Manual: True
   Default: False
 
-Flag optparse-applicative-018
-  Description: use optparse-applicative >=0.18
-  Manual: False
-  Default: False
-
 source-repository head
   type:     git
   location: git://github.com/msakai/toysolver.git
@@ -512,18 +507,12 @@ Executable toyconvert
     containers,
     data-default-class,
     MIP,
+    optparse-applicative >=0.18,
+    prettyprinter >=1,
     pseudo-boolean,
     scientific,
     text,
     toysolver
-  if flag(optparse-applicative-018)
-    Build-Depends:
-      optparse-applicative >=0.18,
-      prettyprinter >=1
-  else
-    Build-Depends:
-      optparse-applicative <0.18,
-      ansi-wl-pprint
   GHC-Options: -rtsopts
 
 Executable toysolver-check

--- a/toysolver.cabal
+++ b/toysolver.cabal
@@ -140,8 +140,10 @@ Library
   Exposed: True
   Hs-source-dirs: src
   Build-Depends:
-     aeson >=1.4.2.0 && <2.3,
-     array >=0.5,
+     -- Data.Aeson.Key requires aeson >=2.0.0
+     aeson >=2.0 && <2.3,
+     -- modifyArray requires array >=0.5.6
+     array >=0.5.6,
      bytestring >=0.9.2.1 && <0.13,
      bytestring-builder,
      bytestring-encoding >=0.1.1.0,
@@ -157,8 +159,8 @@ Library
      extended-reals >=0.1 && <1.0,
      filepath,
      finite-field >=0.9.0 && <1.0.0,
-     -- hashUsing is available on hashable >=1.2
-     hashable >=1.2 && <1.6.0.0,
+     -- defaultHashWithSalt requires hashable >=1.4.3
+     hashable >=1.4.3 && <1.6.0.0,
      hashtables,
      heaps,
      integer-logarithms >=1.0.3.1 && <1.1,


### PR DESCRIPTION
Stop supporting old versions of libraries  and require new versions:

* aeson >=2.0
* array >=0.5.6
* hashable >=1.4.3
* optparse-applicative >=0.18
