### PR TITLE
Update the semantics of zero division on bitvectors to conform to SMT-LIB >=2.6

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,8 @@
 0.10.0 (Unreleased)
 -----
 
+* SMT
+  * Update the semantics of zero division on bitvectors to conform to SMT-LIB >=2.6 (#209)
 * Converter updates
   * Do not produce `obj<T` constraint in wbo2pb when all interpretations are admissible (#157)
   * Optimize `unconstrainPB` a little (#159, #161)

--- a/src/ToySolver/BitVector/Base.hs
+++ b/src/ToySolver/BitVector/Base.hs
@@ -44,8 +44,6 @@ module ToySolver.BitVector.Base
 
 import Prelude hiding (repeat)
 import Data.Bits
-import Data.Map (Map)
-import qualified Data.Map as Map
 import Data.Ord
 import qualified Data.Semigroup as Semigroup
 import qualified Data.Vector as V
@@ -490,10 +488,10 @@ instance BVComparison Expr where
 
 -- ------------------------------------------------------------------------
 
-type Model = (V.Vector BV, Map BV BV, Map BV BV)
+type Model = V.Vector BV
 
 evalExpr :: Model -> Expr -> BV
-evalExpr (env, divTable, remTable) = f
+evalExpr env = f
   where
     f (EConst bv) = bv
     f (EVar v) = env VG.! varId v
@@ -511,23 +509,11 @@ evalExpr (env, divTable, remTable) = f
     evalOp2 OpAdd x y = bvadd x y
     evalOp2 OpMul x y = bvmul x y
     evalOp2 OpUDiv x y
-      | y' /= 0 = bvudiv x y
-      | otherwise =
-          case Map.lookup x divTable of
-            Just d -> d
-            Nothing -> nat2bv (width x) 0
-      where
-        y' :: Integer
-        y' = bv2nat y
+      | bv2nat y /= (0 :: Integer) = bvudiv x y
+      | otherwise = fromAscBits (replicate (width x) True)
     evalOp2 OpURem x y
-      | y' /= 0 = bvurem x y
-      | otherwise =
-          case Map.lookup x remTable of
-            Just r -> r
-            Nothing -> nat2bv (width x) 0
-      where
-        y' :: Integer
-        y' = bv2nat y
+      | bv2nat y /= (0 :: Integer) = bvurem x y
+      | otherwise = x
     evalOp2 OpSDiv x y
       | width x < 1 || width y < 1 || width x /= width y = error "invalid width"
       | not msb_x && not msb_y = evalOp2 OpUDiv x y

--- a/src/ToySolver/BitVector/Solver.hs
+++ b/src/ToySolver/BitVector/Solver.hs
@@ -61,7 +61,6 @@ data Solver
   , svSATSolver :: SAT.Solver
   , svTseitin :: Tseitin.Encoder IO
   , svEncTable :: IORef (Map Expr (VU.Vector SAT.Lit))
-  , svDivRemTable :: IORef [(VU.Vector SAT.Lit, VU.Vector SAT.Lit, VU.Vector SAT.Lit, VU.Vector SAT.Lit)]
   , svAtomTable :: IORef (Map NormalizedAtom SAT.Lit)
   , svContexts :: Vec.Vec (IntMap (Maybe Int))
   }
@@ -72,7 +71,6 @@ newSolver = do
   sat <- SAT.newSolver
   tseitin <- Tseitin.newEncoder sat
   table <- newIORef Map.empty
-  divRemTable <- newIORef []
   atomTable <- newIORef Map.empty
   contexts <- Vec.new
   Vec.push contexts IntMap.empty
@@ -82,7 +80,6 @@ newSolver = do
     , svSATSolver = sat
     , svTseitin = tseitin
     , svEncTable = table
-    , svDivRemTable = divRemTable
     , svAtomTable = atomTable
     , svContexts = contexts
     }
@@ -158,10 +155,7 @@ getModel solver = do
   let f = fromAscBits . map (SAT.evalLit m) . VG.toList
       isZero' = not . or . toAscBits
       env = VG.fromList [f vs | vs <- vss]
-  xs <- readIORef (svDivRemTable solver)
-  let divTable = Map.fromList [(f s, f d) | (s,t,d,_r) <- xs, isZero' (f t)]
-      remTable = Map.fromList [(f s, f r) | (s,t,_d,r) <- xs, isZero' (f t)]
-  return (env, divTable, remTable)
+  return env
 
 explain :: Solver -> IO IntSet
 explain solver = do
@@ -387,12 +381,12 @@ encodeDivRem solver s t = do
   c <- do
     tmp <- encodeMul (svTseitin solver) False d t
     encodeSum (svTseitin solver) w False [tmp, r]
-  tbl <- readIORef (svDivRemTable solver)
+  -- Semantics of division and remainder operators has been changed in SMT-LIB 2.6.
+  -- 
   Tseitin.addFormula (svTseitin solver) $
     ite (isZero t)
-        (And [(isEQ s s' .&&. isZero t') .=>. (isEQ d d' .&&. isEQ r r') | (s',t',d',r') <- tbl, w == VG.length s'])
+        (And [Atom l | l <- VG.toList d] .&&. And ([Atom a .<=>. Atom b | (a,b) <- zip (VG.toList s) (VG.toList r)]))
         (isEQ s c .&&. isULT r t)
-  modifyIORef (svDivRemTable solver) ((s,t,d,r) :)
   return (d,r)
 
 encodeSDiv :: Solver -> SBV -> SBV -> IO SBV

--- a/src/ToySolver/BitVector/Solver.hs
+++ b/src/ToySolver/BitVector/Solver.hs
@@ -153,7 +153,6 @@ getModel solver = do
   m <- SAT.getModel (svSATSolver solver)
   vss <- Vec.getElems (svVars solver)
   let f = fromAscBits . map (SAT.evalLit m) . VG.toList
-      isZero' = not . or . toAscBits
       env = VG.fromList [f vs | vs <- vss]
   return env
 
@@ -382,10 +381,9 @@ encodeDivRem solver s t = do
     tmp <- encodeMul (svTseitin solver) False d t
     encodeSum (svTseitin solver) w False [tmp, r]
   -- Semantics of division and remainder operators has been changed in SMT-LIB 2.6.
-  -- 
   Tseitin.addFormula (svTseitin solver) $
     ite (isZero t)
-        (And [Atom l | l <- VG.toList d] .&&. And ([Atom a .<=>. Atom b | (a,b) <- zip (VG.toList s) (VG.toList r)]))
+        (And [Atom l | l <- VG.toList d] .&&. isEQ s r)
         (isEQ s c .&&. isULT r t)
   return (d,r)
 

--- a/src/ToySolver/SMT.hs
+++ b/src/ToySolver/SMT.hs
@@ -1269,28 +1269,6 @@ modelGetAssertions m =
   | let FEUFFun _ sym = mDefs m Map.! "_/0"
   , ([arg], result) <- Map.toList $ EUF.mFunctions (mEUFModel m) IntMap.! sym
   ]
-  ++
-  [ EAp "="
-      [ EAp "bvudiv"
-        [ EValue (ValBitVec s)
-        , EValue (ValBitVec (BV.nat2bv (BV.width s) 0))
-        ]
-      , EValue (ValBitVec t)
-      ]
-  | (s,t) <- Map.toList bvDivTable
-  ]
-  ++
-  [ EAp "="
-      [ EAp "bvurem"
-        [ EValue (ValBitVec s)
-        , EValue (ValBitVec (BV.nat2bv (BV.width s) 0))
-        ]
-      , EValue (ValBitVec t)
-      ]
-  | (s,t) <- Map.toList bvRemTable
-  ]
-  where
-    (_, bvDivTable, bvRemTable) = mBVModel m
 
 -- -------------------------------------------------------------------
 

--- a/test/Test/BitVector.hs
+++ b/test/Test/BitVector.hs
@@ -48,6 +48,8 @@ case_division_by_zero = do
   v1 <- BV.newVar solver 8
   v2 <- BV.newVar solver 8
   let z = BV.nat2bv 8 0
+  BV.assertAtom solver (BV.bvudiv v1 z .==. BV.nat2bv 8 255) Nothing
+  BV.assertAtom solver (BV.bvurem v1 z .==. v1) Nothing
   BV.assertAtom solver (BV.bvudiv v1 z ./=. BV.bvudiv v2 z) Nothing
   ret <- BV.check solver
   ret @?= False

--- a/test/Test/BitVector.hs
+++ b/test/Test/BitVector.hs
@@ -40,18 +40,17 @@ prop_BVSolver = QM.monadicIO $ do
       QM.monitor (counterexample $ show m)
       QM.assert $ and [BV.evalAtom m c | c <- cs]
 
-case_division_by_zero_cong :: IO ()
-case_division_by_zero_cong = do
+-- Since SMT-LIB 2.6, the result of division by zero has been fixed to be a bit vector with all bits set to 1.
+-- Before SMT-LIB 2.6, this was satisfiable.
+case_division_by_zero :: IO ()
+case_division_by_zero = do
   solver <- BV.newSolver
   v1 <- BV.newVar solver 8
   v2 <- BV.newVar solver 8
   let z = BV.nat2bv 8 0
   BV.assertAtom solver (BV.bvudiv v1 z ./=. BV.bvudiv v2 z) Nothing
   ret <- BV.check solver
-  ret @?= True
-  BV.assertAtom solver (v1 .==. v2) Nothing
-  ret2 <- BV.check solver
-  ret2 @?= False
+  ret @?= False
 
 -- ------------------------------------------------------------------------
 -- Generators


### PR DESCRIPTION
Before SMT-LIB 2.6, the result of division by zero was unspecified and could be freely chosen as long as the congruence condition is satisfied. However, SMT-LIB 2.6 standardized that the result of division by zero must be a bit vector with all bits set to 1, and that the remainder must be the same as the dividend.

https://smt-lib.org/theories-FixedSizeBitVectors.shtml

```
   [[(bvudiv s t)]] := if bv2nat([[t]]) = 0
                       then λx:[0, m). 1
                       else nat2bv[m](bv2nat([[s]]) div bv2nat([[t]]))

   [[(bvurem s t)]] := if bv2nat([[t]]) = 0
                       then [[s]]
                       else nat2bv[m](bv2nat([[s]]) mod bv2nat([[t]]))
```

(Reference) Related discussions on the SMT-LIB mailing list: [[SMT-LIB] QF_BV and division by zero](https://web.archive.org/web/20220422100432/https://cs.nyu.edu/pipermail/smt-lib/2015/000977.html)