### PR TITLE
test: bound exponents in multivariate monomial generator to fix intermittent CI timeout

### DIFF
--- a/test/TestPolynomial.hs
+++ b/test/TestPolynomial.hs
@@ -563,7 +563,7 @@ monicMonomials = do
   size <- choose (0, 3)
   xs <- replicateM size $ do
     v <- choose (-5, 5)
-    e <- liftM ((+1) . abs) arbitrary
+    e <- choose (1, 4)
     return $ P.var v `P.mpow` e
   return $ foldl' P.mmult P.mone xs
 


### PR DESCRIPTION
## Summary

`prop_divModMP` in `test/TestPolynomial.hs` occasionally makes the test suite exceed the `timeout-minutes: 10` budget in `.github/workflows/build.yaml`. This PR addresses the root cause with a one-line change to a test-data generator.

## Root cause

The multivariate monomial generator `monicMonomials` drew exponents with:

```haskell
e <- liftM ((+1) . abs) arbitrary   -- Integer, scales with the QuickCheck size (up to ~100)
```

while the univariate counterpart `umonicMonomials` already bounds them with `choose (1, 4)`. This asymmetry let `monicMonomials` produce very high-degree monomials (degree 50–100) over a small variable set (11 variables), which makes the multivariate division in `prop_divModMP` blow up.

### Reproduction (standalone, GHC 9.10, `-O2`, native — CI's coverage build is much slower)

Reproducing the exact generator + `divModMP` over many random instances:

| size | worst case | reduction steps | max intermediate terms | remainder coeff digits |
|------|-----------|-----------------|------------------------|------------------------|
| 20 | 0.95 s | 9,165 | 808 | ~89 |
| 40 | 2.6 s | 8,855 | 1,771 | ~250 |
| 60 | **5.3 s** | 10,834 | **3,245** | ~260 |

A single unlucky instance can take several seconds (much longer under HPC `--coverage` on the GHC 9.8 CI job), which is enough to intermittently push the whole suite past 10 minutes. It is intermittent because only certain random structures trigger it (a divisor whose lex-leading monomial is a low power of the most-significant variable, against high powers of that variable in the dividend).

## Fix

Bound the exponent with `choose (1, 4)`, matching the existing `umonicMonomials`.

With the cap, the blow-up disappears entirely:

| | worst case | total over 3000 instances | max intermediate terms |
|---|-----------|---------------------------|------------------------|
| before (unbounded exponent) | 5,300 ms | 5,500 ms | 3,245 |
| after (`choose (1,4)`) | **4 ms** | **30 ms** | 64 |

## Notes

- No correctness bug was found in `divModMP`; the property held in all 10k+ random instances exercised during investigation.
- A separate, optional algorithmic improvement (rewriting `divModMP` to a textbook leading-term reduction, ~2× faster and lower memory) is deferred to a follow-up PR after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw7dAHg8JrjRxJqu7kC2z4)_