### PR TITLE
toysmt: suppress prompt and avoid haskeline when stdin is not a terminal

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,6 +3,7 @@
 
 * SMT
   * Update the semantics of zero division on bitvectors to conform to SMT-LIB >=2.6 (#209)
+  * `toysmt` now suppresses the prompt and does not use haskeline when stdin is not a terminal
 * Converter updates
   * Do not produce `obj<T` constraint in wbo2pb when all interpretations are admissible (#157)
   * Optimize `unconstrainPB` a little (#159, #161)

--- a/app/toysmt/toysmt.hs
+++ b/app/toysmt/toysmt.hs
@@ -17,6 +17,7 @@ module Main where
 import Data.Version
 import Options.Applicative hiding (Parser)
 import qualified Options.Applicative as Opt
+import Control.Monad (when)
 import qualified Data.Text.IO as T
 #ifdef USE_HASKELINE_PACKAGE
 import Control.Monad.IO.Class (liftIO)
@@ -24,9 +25,8 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified System.Console.Haskeline as Haskeline
 import Language.SMTLIB.Parser (frameCommand, Result (..))
-#else
-import Language.SMTLIB.Reader.Handle (newHandleReader, readCommand)
 #endif
+import Language.SMTLIB.Reader.Handle (newHandleReader, readCommand)
 import System.Exit
 import System.IO
 
@@ -104,21 +104,29 @@ loadFile solver fname = do
 
 repl :: Solver -> IO ()
 repl solver = do
+  -- Use the interactive frontend (prompt, and line editing via haskeline if
+  -- available) only when stdin is connected to a terminal. When stdin is a pipe
+  -- or a regular file, toysmt is typically driven by another program over the
+  -- SMT-LIB protocol; in that case we suppress the prompt so that it does not
+  -- pollute the response stream on stdout, and we avoid haskeline entirely.
+  tty <- hIsTerminalDevice stdin
 #ifdef USE_HASKELINE_PACKAGE
-  replHaskeline solver
+  if tty then
+    replHaskeline solver
+  else
+    replSimple False solver
 #else
-  replSimple solver
+  replSimple tty solver
 #endif
 
-#ifndef USE_HASKELINE_PACKAGE
-
-replSimple :: Solver -> IO ()
-replSimple solver = do
+replSimple :: Bool -> Solver -> IO ()
+replSimple showPrompt solver = do
   hSetBuffering stdin LineBuffering
   hr <- newHandleReader stdin
   let loop = do
-        putStr "toysmt> "
-        hFlush stdout
+        when showPrompt $ do
+          putStr "toysmt> "
+          hFlush stdout
         r <- readCommand hr
         case r of
           Left err -> do
@@ -129,8 +137,6 @@ replSimple solver = do
             execCommand solver (noAnn cmd)
             loop
   loop
-
-#endif
 
 #ifdef USE_HASKELINE_PACKAGE
 


### PR DESCRIPTION
## Summary

Improve `toysmt` behavior when used in non-interactive contexts (pipes, files, or programmatic invocation) by detecting whether stdin is connected to a terminal and adjusting the REPL accordingly.

## Changes

- **Terminal detection**: Added `hIsTerminalDevice stdin` check to determine if stdin is a terminal
- **Conditional REPL mode**: 
  - When stdin is a terminal: use the interactive frontend with haskeline (if available) and prompt
  - When stdin is not a terminal: use simple REPL without prompt and without haskeline overhead
- **Unified replSimple function**: Moved `replSimple` outside the `#ifndef USE_HASKELINE_PACKAGE` guard and added a `showPrompt` parameter to control prompt display
- **Import reorganization**: Moved `Language.SMTLIB.Reader.Handle` imports outside conditional compilation blocks since it's now used in both code paths
- **Added Control.Monad import**: For the `when` function used in conditional prompt display

## Rationale

When `toysmt` is driven by another program over the SMT-LIB protocol (stdin is a pipe or file), the interactive prompt pollutes the response stream on stdout. This change suppresses the prompt in such cases and avoids the haskeline library entirely when not needed, improving compatibility with automated SMT-LIB clients while maintaining the interactive experience for terminal users.

https://claude.ai/code/session_01EYEhwkUrhFT6T3CnXGE5z2