### PR TITLE
Fix infinite loop on framing errors in the toysmt haskeline REPL

### DIFF
--- a/app/toysmt/toysmt.hs
+++ b/app/toysmt/toysmt.hs
@@ -161,9 +161,12 @@ replHaskeline solver = Haskeline.runInputT Haskeline.defaultSettings $ loop T.em
         Done (Left err) rest -> do
           liftIO $ hPutStr stderr (errorBundlePretty err)
           continue rest
-        Failed err rest -> do
+        Failed err _ -> do
+          -- A framing error (e.g. a stray top-level ')') is not consumed by the
+          -- framer, so its leftover would re-trigger the same error forever.
+          -- Discard the buffer and prompt afresh.
           liftIO $ hPutStrLn stderr ("framing error: " ++ show err)
-          continue rest
+          loop T.empty
 
     continue :: Text -> Haskeline.InputT IO ()
     continue rest


### PR DESCRIPTION
## Problem

Typing input that produces a framing error at the `toysmt>` prompt (most easily a stray top-level `)`) made the haskeline REPL spin forever, printing `framing error: UnexpectedCloseParen` repeatedly.

The framer does **not** consume the offending input on a `Failed` result — the returned leftover still starts with the bad character. The `Failed` branch fed that leftover to `continue`, which re-framed it into the same `Failed`, looping indefinitely:

```haskell
Failed err rest -> do
  liftIO $ hPutStrLn stderr ("framing error: " ++ show err)
  continue rest        -- re-frames the same unconsumed input → loop
```

(The `Done (Left …)` syntax-error branch is fine: there the framer consumed a complete frame, so `rest` is genuinely past it. The plain non-tty `replSimple` path is also unaffected, since `Language.SMTLIB.Reader.Handle.readCommand` drops the leftover on a framing error.)

## Fix

Discard the buffer and return to a fresh prompt:

```haskell
Failed err _ -> do
  liftIO $ hPutStrLn stderr ("framing error: " ++ show err)
  loop T.empty
```

This matches `replSimple`'s effective behavior (drop and continue). Recovering past just the offending token would require the framer to expose a resync point, which it does not — so dropping the line is the pragmatic choice for interactive error recovery.

## Testing

Reproduced and verified under a pseudo-terminal (the loop only manifests on the tty/haskeline path):

| input | before | after |
|---|---|---|
| `)\n` (read for 2.5s) | **55558** `framing error` lines, never exits | **1** line, waits at prompt |
| `)\n(exit)\n` | flood | **1** line, then clean exit (recovers and runs `(exit)`) |

`stack build` is clean; sample files (e.g. `samples/smt/QF_UF.smt2`) still behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)