### PR TITLE
Support define-const command in ToySolver.SMT.SMTLIB2Solver

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,6 +3,7 @@
 
 * SMT
   * Migrate toysmt to use newly developed [language-smtlib](https://hackage.haskell.org/package/language-smtlib) from `Smtlib` fork (#206, #214)
+  * Support `define-const` command in `ToySolver.SMT.SMTLIB2Solver`
   * Update the semantics of zero division on bitvectors to conform to SMT-LIB >=2.6 (#209)
   * `toysmt` now suppresses the prompt and does not use haskeline when stdin is not a terminal
 * Converter and `toyconvert` command

--- a/src/ToySolver/SMT/SMTLIB2Solver.hs
+++ b/src/ToySolver/SMT/SMTLIB2Solver.hs
@@ -44,6 +44,7 @@ module ToySolver.SMT.SMTLIB2Solver
   , defineSort
   , declareConst
   , declareFun
+  , defineConst
   , defineFun
   , defineFunRec
   , defineFunsRec
@@ -339,6 +340,7 @@ runCommand solver cmd = E.handle h $ do
     DeclareSort name arity () -> const RSuccess <$> declareSort solver (T.unpack name) (fromInteger arity)
     DefineSort name xs body () -> const RSuccess <$> defineSort solver (T.unpack name) (map T.unpack xs) body
     DeclareConst name y () -> const RSuccess <$> declareConst solver (T.unpack name) y
+    DefineConst name y body () -> const RSuccess <$> defineConst solver (T.unpack name) y body
     DeclareFun name xs y () -> const RSuccess <$> declareFun solver (T.unpack name) xs y
     DefineFun (FunctionDef name xs y body ()) () -> const RSuccess <$> defineFun solver (T.unpack name) xs y body
     DefineFunRec (FunctionDef name xs y body ()) () -> const RSuccess <$> defineFunRec solver (T.unpack name) xs y body
@@ -358,7 +360,6 @@ runCommand solver cmd = E.handle h $ do
     Echo s () -> REcho <$> echo solver s
     Exit () -> const RSuccess <$> exit solver
     -- Commands without solver support
-    DefineConst _ _ _ () -> E.throwIO SMT.Unsupported
     DeclareDatatype _ _ () -> E.throwIO SMT.Unsupported
     DeclareDatatypes _ _ () -> E.throwIO SMT.Unsupported
     DeclareSortParameter _ () -> E.throwIO SMT.Unsupported
@@ -633,6 +634,10 @@ defineSort solver name xs body = do
 
 declareConst :: Solver -> String -> Sort () -> IO ()
 declareConst solver name y = declareFun solver name [] y
+
+-- | @(define-const c σ t)@ is syntactic sugar for @(define-fun c () σ t)@.
+defineConst :: Solver -> String -> Sort () -> Term () -> IO ()
+defineConst solver name y body = defineFun solver name [] y body
 
 declareFun :: Solver -> String -> [Sort ()] -> Sort () -> IO ()
 declareFun solver name xs y = do

--- a/test/Test/SMTLIB2Solver.hs
+++ b/test/Test/SMTLIB2Solver.hs
@@ -56,6 +56,15 @@ case_declareConst = do
   assertSuccess =<< SMTLIB2.runCommandString solver "(declare-const x Bool)"
   assertSuccess =<< SMTLIB2.runCommandString solver "(declare-const y Bool)"
 
+case_defineConst :: Assertion
+case_defineConst = do
+  solver <- SMTLIB2.newSolver
+  SMTLIB2.setLogic solver "QF_LRA"
+  assertSuccess =<< SMTLIB2.runCommandString solver "(define-const x Real 3)"
+  assertSuccess =<< SMTLIB2.runCommandString solver "(assert (not (= x 3)))"
+  r <- SMTLIB2.checkSat solver
+  r @?= Unsat
+
 case_divisionByZero :: Assertion
 case_divisionByZero = do
   solver <- SMTLIB2.newSolver


### PR DESCRIPTION
`define-const` is introduced in SMT-LIB Version 2.7.

`(define-const c σ t)` is handled as syntactic sugar for `(define-fun c () σ t)`, mirroring how `declare-const` delegates to `declare-fun`.